### PR TITLE
NON-JIRA FEAT (Tabs) Remove unneeded import

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/travel-information/travel-information-tab.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/travel-information/travel-information-tab.ftl
@@ -1,4 +1,3 @@
-<#include "../../../../frontend/components/b-tab.ftl">
 <#include "../../../../frontend/components/vs-tab-item.ftl">
 <#include "../../../../frontend/components/vs-accordion.ftl">
 <#include "../../../../frontend/components/vs-accordion-item.ftl">


### PR DESCRIPTION
The file doesn't exist and this doesn't need an import, the btab code comes from within the vs-tab-item scripts and we can just use the component by name here