### PR TITLE
Prevent dependabot from raising PRs for version updates in maven ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This should still allow dependabot to create PRs for security updates