### PR TITLE
non-jira: set develop-nightly to build a fresh container every time to improve stability

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ if (BRANCH_NAME == "develop" && (JOB_NAME == "develop.visitscotland.com/develop"
 } else if (BRANCH_NAME == "develop" && (JOB_NAME == "develop-nightly.visitscotland.com/develop" || JOB_NAME == "develop-nightly.visitscotland.com-mb/develop")) {
   thisAgent = "op-dev-xvcdocker-01"
   env.VS_CONTAINER_BASE_PORT_OVERRIDE = "8098"
+  env.VS_CONTAINER_PRESERVE = "FALSE"
   cron_string = "@midnight"
 } else if (BRANCH_NAME == "develop" && (JOB_NAME == "develop-stable.visitscotland.com/develop" || JOB_NAME == "develop-stable.visitscotland.com-mb/develop")) {
   thisAgent = "op-dev-xvcdocker-01"


### PR DESCRIPTION
Hi @BrianGibbVS,

With reference to the conversation in last week's planning meeting, I have set the variable VS_CONTAINER_PRESERVE to FALSE with building the develop-nightly job. This should prevent build failures stemming from local data being incompatible with changes to the data model in the project.

There are still other reasons that the site might not be available after the nightly build but we can handle those as they arise.