### PR TITLE
fix(itineraries): remove colon from day-transport that duplicates component library

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/itinerary-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/itinerary-main.ftl
@@ -65,7 +65,7 @@
                                     title
                                     class="col-auto px-0"
                                 >
-                                    ${label("itinerary", "transport")}:
+                                    ${label("itinerary", "transport")}
                                 </vs-description-list-item>
                                 <#list day.transports as transport>
                                     <vs-description-list-item 


### PR DESCRIPTION
This is causing a double colon as vs-description-list-item automatically adds one to inline terms

![image](https://github.com/user-attachments/assets/5afe3dca-51aa-4476-bb8e-c868f8305e92)
