### PR TITLE
Fix issue with nested headings

### DIFF
--- a/site/components/src/main/java/com/visitscotland/brxm/config/DeliveryAPIContentRewriter.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/config/DeliveryAPIContentRewriter.java
@@ -40,7 +40,7 @@ public class DeliveryAPIContentRewriter extends HtmlContentRewriter {
         try {
             if (node != null) {
                 parentDocument = node.getPath();
-                if (parentDocument.endsWith("/visitscotland:paragraph/visitscotland:copy")
+                if (parentDocument.endsWith("/visitscotland:copy") && parentDocument.contains("/visitscotland:paragraph")
                         && node.getParent().getParent().hasProperty(NESTED)) {
                     nested = node.getParent().getParent().getProperty(NESTED).getBoolean();
                 }


### PR DESCRIPTION
"When adding a nested article, only the first paragraph changes the h values, while any other paragraphs retains the old h value."

The issue was due to a path that only worked for the first section (/visitscoland:paragraph/visitscotland:copy) but not for the subsequent ones (i.e /visitscoland:paragraph[2]/visitscotland:copy)