### PR TITLE
feat(icons): implement icon lookup in freemarker

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/key-facilities.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/global/key-facilities.ftl
@@ -1,11 +1,15 @@
 <#include "../../../frontend/components/vs-icon-list.ftl">
 <#include "../../../frontend/components/vs-icon-list-item.ftl">
 
+<#include "../shared/icon-lookup.ftl">
+
 <#macro keyFacilities facilitiesList>
     <vs-icon-list title="${label('essentials.global', 'keyfacilities.title')}">
         <#list facilitiesList as facility>
+            <#assign iconName = iconLookup(facility.id)>
+
             <vs-icon-list-item
-                icon="${facility.id}"
+                icon="${iconName}"
                 label="${facility.name}">
             </vs-icon-list-item>
         </#list>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/footer/footer-social-menu.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/footer/footer-social-menu.ftl
@@ -3,6 +3,8 @@
 <#include "../../../../frontend/components/vs-footer-social-item.ftl">
 <#include "../../../../frontend/components/vs-list.ftl">
 
+<#include "../../shared/icon-lookup.ftl">
+
 <#macro footerSocialMenu>
     <vs-footer-social-menu>
         <template v-slot:title>
@@ -11,19 +13,19 @@
 
         <vs-footer-social-item
             href="${optionalLabel('navigation.social-media', 'facebook')}"
-            icon="facebook"
+            icon="${iconLookup('facebook')}"
         ></vs-footer-social-item>
         <vs-footer-social-item
             href="${optionalLabel('navigation.social-media', 'twitter')}"
-            icon="x-twitter"
+            icon="${iconLookup('x-twitter')}"
         ></vs-footer-social-item>
         <vs-footer-social-item
             href="${optionalLabel('navigation.social-media', 'youtube')}"
-            icon="youtube"
+            icon="${iconLookup('youtube')}"
         ></vs-footer-social-item>
         <vs-footer-social-item
             href="${optionalLabel('navigation.social-media', 'instagram')}"
-            icon="instagram"
+            icon="${iconLookup('instagram')}"
         ></vs-footer-social-item>
     </vs-footer-social-menu>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/shared/icon-lookup.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/shared/icon-lookup.ftl
@@ -1,0 +1,100 @@
+<#function iconLookup inputName="">
+    <#switch inputName>
+        <#case "accesstoliet">
+            <#return "accessible-toilet">
+            <#break>
+        <#case "accessparkdrop">
+            <#return "facility-accessparkdrop">
+            <#break>
+        <#case "acco">
+            <#return "product-accommodation">
+            <#break>
+        <#case "acti">
+            <#return "product-activitie">
+            <#break>
+        <#case "attr">
+            <#return "product-attractions">
+            <#break>
+        <#case "audioloop">
+            <#return "facility-audioloop">
+            <#break>
+        <#case "cafereston">
+            <#return "cafe">
+            <#break>
+        <#case "cate">
+            <#return "product-food-and-drink">
+            <#break>
+        <#case "cities">
+            <#return "city">
+            <#break>
+        <#case "cycling">
+            <#return "cycle">
+            <#break>
+        <#case "dsblaccess">
+            <#return "facility-dsblaccess">
+            <#break>
+        <#case "wheelchairaccess">
+            <#return "facility-dsblaccess">
+            <#break>
+        <#case "even">
+            <#return "product-events">
+            <#break>
+        <#case "familyev">
+            <#return "family">
+            <#break>
+        <#case "filmev">
+            <#return "film-tv">
+            <#break>
+        <#case "hottub">
+            <#return "hot-tub">
+            <#break>
+        <#case "parking">
+            <#return "facility-parking">
+            <#break>
+        <#case "petswelcom">
+            <#return "facility-petswelcom">
+            <#break>
+        <#case "wifi">
+            <#return "facility-wifi">
+            <#break>
+        <#case "public">
+            <#return "public-transport">
+            <#break>
+        <#case "pubtranrte">
+            <#return "public-transport">
+            <#break>
+        <#case "reta">
+            <#return "product-shopping">
+            <#break>
+        <#case "spahealth">
+            <#return "wellness">
+            <#break>
+        <#case "vege">
+            <#return "vegan-vegetarian">
+            <#break>
+        <#case "walking">
+            <#return "walk">
+            <#break>
+        <#case "boat">
+            <#return "boat">
+            <#break>
+        <#case "transport">
+            <#return "transport">
+            <#break>
+        <#case "brekavail">
+            <#return "breakfast-available">
+            <#break>
+        <#case "wetroom">
+            <#return "level-entry-shower">
+            <#break>
+        <#case "x-twitter">
+            <#return "x-twitter fa-brands">
+            <#break>
+        <#case "linkedin">
+            <#return "linkedin-in fa-brands">
+            <#break>
+        <#default>
+            <#return inputName>
+            <#break>
+    </#switch>
+</#function>


### PR DESCRIPTION
Reimplements the icon lookup that currently occurs in the component library in freemarker, and attaches it in the two relevant locations (key facilities and the social icons in the footer since the twitter/x rebrand)

I think we can merge this post-release, we're going to remove the existing lookup system from the component library at some point after this release so it isn't needed and it gives us slightly longer to test