### PR TITLE
DS-806-BACK-END-HELPERS - Migrate FTL helper methods

### DIFF
--- a/site/components/src/main/java/com/visitscotland/brxm/utils/JsonEscaper.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/JsonEscaper.java
@@ -1,0 +1,20 @@
+package com.visitscotland.brxm.utils;
+
+public final class JsonEscaper {
+    private JsonEscaper() { }
+
+    public static String escape(String original, boolean isJsonObject) {
+        String escaped = original.replace("'", "\\'");
+        escaped = isJsonObject ? escapeJsonObject(escaped) : escapeQuotes(escaped);
+
+        return escaped;
+    }
+
+    private static String escapeJsonObject(final String json) {
+        return json.replace("\"", "'");
+    }
+
+    private static String escapeQuotes(final String json) {
+        return json.replace("\"", "&quot;");
+    }
+}

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/UrlParameterAppender.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/UrlParameterAppender.java
@@ -1,0 +1,9 @@
+package com.visitscotland.brxm.utils;
+
+public final class UrlParameterAppender {
+    private UrlParameterAppender() { }
+
+    public static String addParameter(String url) {
+        return url.contains("?") ? "&" : "?";
+    }
+}

--- a/site/components/src/main/java/com/visitscotland/brxm/utils/UrlResolver.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/utils/UrlResolver.java
@@ -1,0 +1,31 @@
+package com.visitscotland.brxm.utils;
+
+import com.visitscotland.brxm.components.navigation.MenuItem;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class UrlResolver {
+    private static final String HASHTAG_URL_FALLBACK = "#";
+    private static final String PAGE_NOT_FOUND = "pagenotfound";
+    private UrlResolver() { }
+
+    public static String getUrl(final MenuItem menuItem) {
+        return Optional
+            .ofNullable(menuItem)
+            .map(UrlResolver::extractLink)
+            .orElse(HASHTAG_URL_FALLBACK);
+    }
+
+    private static String extractLink(final MenuItem menuItem) {
+        if (Objects.nonNull(menuItem.getPage())) {
+            return menuItem.getPlainLink();
+        } else if (Objects.nonNull(menuItem.getHstLink())) {
+            return PAGE_NOT_FOUND;
+        } else if (Objects.nonNull(menuItem.getExternalLink())) {
+            return menuItem.getExternalLink().replace("\"", "");
+        }
+
+        return HASHTAG_URL_FALLBACK;
+    }
+}

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/JsonEscaperTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/JsonEscaperTest.java
@@ -1,0 +1,99 @@
+package com.visitscotland.brxm.utils;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JsonEscaperTest {
+    @Test
+    void When_Escape_With_JsonString_Expect_EscapedJson() {
+        final String input = "{\"name\": \"John\"}";
+        final boolean isJsonObject = true;
+        final String expected = "{'name': 'John'}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_NonJsonString_Expect_EscapedString() {
+        final String input = "{\"name\": \"John\"}";
+        final boolean isJsonObject = false;
+        final String expected = "{&quot;name&quot;: &quot;John&quot;}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_EmptyString_Expect_EmptyString() {
+        final String input = "";
+        final boolean isJsonObject = true;
+        final String expected = "";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_SingleQuote_Expect_EscapedSingleQuote() {
+        final String input = "{\"name\": \"O'Reilly\"}";
+        final boolean isJsonObject = true;
+        final String expected = "{'name': 'O\\'Reilly'}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_DoubleQuoteInJson_Expect_SingleQuote() {
+        final String input = "{\"name\": \"John\"}";
+        final boolean isJsonObject = true;
+        final String expected = "{'name': 'John'}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_DoubleQuoteInNonJson_Expect_HtmlEntity() {
+        final String input = "{\"name\": \"John\"}";
+        final boolean isJsonObject = false;
+        final String expected = "{&quot;name&quot;: &quot;John&quot;}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_MixedQuotesInJson_Expect_EscapedMixedQuotes() {
+        final String input = "{\"quote\": \"He said, 'Hello'\"}";
+        final boolean isJsonObject = true;
+        final String expected = "{'quote': 'He said, \\'Hello\\''}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_MixedQuotesInNonJson_Expect_EscapedMixedQuotes() {
+        final String input = "{\"quote\": \"He said, 'Hello'\"}";
+        final boolean isJsonObject = false;
+        final String expected = "{&quot;quote&quot;: &quot;He said, \\'Hello\\'&quot;}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_NestedJson_Expect_EscapedNestedJson() {
+        final String input = "{\"person\": {\"name\": \"John\", \"age\": 30}}";
+        final boolean isJsonObject = true;
+        final String expected = "{'person': {'name': 'John', 'age': 30}}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+
+    @Test
+    void When_Escape_With_NestedNonJson_Expect_EscapedNestedNonJson() {
+        final String input = "{\"person\": {\"name\": \"John\", \"age\": 30}}";
+        final boolean isJsonObject = false;
+        final String expected = "{&quot;person&quot;: {&quot;name&quot;: &quot;John&quot;, &quot;age&quot;: 30}}";
+
+        Assertions.assertEquals(expected, JsonEscaper.escape(input, isJsonObject));
+    }
+}

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/UrlParameterAppenderTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/UrlParameterAppenderTest.java
@@ -1,0 +1,49 @@
+package com.visitscotland.brxm.utils;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UrlParameterAppenderTest {
+    @Test
+    public void When_UrlWithoutQuery_Expect_QuestionMark() {
+        final String url = "http://example.com";
+        final String expected = "?";
+
+        Assertions.assertEquals(expected, UrlParameterAppender.addParameter(url));
+    }
+
+    @Test
+    public void When_UrlWithQuery_Expect_Ampersand() {
+        final String url = "http://example.com?param=value";
+        final String expected = "&";
+
+        Assertions.assertEquals(expected, UrlParameterAppender.addParameter(url));
+    }
+
+    @Test
+    public void When_UrlWithMultipleQueryParams_Expect_Ampersand() {
+        final String url = "http://example.com?param1=value1&param2=value2";
+        final String expected = "&";
+
+        Assertions.assertEquals(expected, UrlParameterAppender.addParameter(url));
+    }
+
+    @Test
+    public void When_EmptyUrl_Expect_QuestionMark() {
+        final String url = "";
+        final String expected = "?";
+
+        Assertions.assertEquals(expected, UrlParameterAppender.addParameter(url));
+    }
+
+    @Test
+    public void When_UrlWithFragment_Expect_QuestionMark() {
+        final String url = "http://example.com#section";
+        final String expected = "?";
+
+        Assertions.assertEquals(expected, UrlParameterAppender.addParameter(url));
+    }
+}

--- a/site/components/src/test/java/com/visitscotland/brxm/utils/UrlResolverTest.java
+++ b/site/components/src/test/java/com/visitscotland/brxm/utils/UrlResolverTest.java
@@ -1,0 +1,86 @@
+package com.visitscotland.brxm.utils;
+
+import com.visitscotland.brxm.components.navigation.MenuItem;
+import com.visitscotland.brxm.hippobeans.Page;
+
+import org.hippoecm.hst.core.linking.HstLink;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.Mockito;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UrlResolverTest {
+    @Mock
+    private MenuItem menuItem;
+
+    private static final String HASHTAG = "#";
+
+    @Test
+    void When_GetUrl_WithPlainLink_ExpectPlainLinkReturned() {
+        final Page page = Mockito.mock(Page.class);
+        final String expected = "https://example.com";
+
+        when(menuItem.getPage()).thenReturn(page);
+        when(menuItem.getPlainLink()).thenReturn(expected);
+
+        assertEquals(expected, UrlResolver.getUrl(menuItem));
+        verify(menuItem, times(1)).getPlainLink();
+    }
+
+    @Test
+    void When_GetUrl_WithHstLink_ExpectPageNotFoundReturned() {
+        final HstLink hstLink = Mockito.mock(HstLink.class);
+        final String expected = "pagenotfound";
+
+        when(menuItem.getPage()).thenReturn(null);
+        when(menuItem.getHstLink()).thenReturn(hstLink);
+
+        assertEquals(expected, UrlResolver.getUrl(menuItem));
+
+        verify(menuItem, times(1)).getPage();
+        verify(menuItem, times(1)).getHstLink();
+    }
+
+    @Test
+    void When_GetUrl_WithExternalLink_ExpectExternalLinkWithoutQuotesReturned() {
+        final String input = "\"https://external.com\"";
+        final String expected = "https://external.com";
+
+        when(menuItem.getPage()).thenReturn(null);
+        when(menuItem.getHstLink()).thenReturn(null);
+        when(menuItem.getExternalLink()).thenReturn(input);
+
+        assertEquals(expected, UrlResolver.getUrl(menuItem));
+
+        verify(menuItem, times(1)).getPage();
+        verify(menuItem, times(1)).getHstLink();
+        verify(menuItem, times(2)).getExternalLink();
+    }
+
+    @Test
+    void When_GetUrl_WithNoLinks_ExpectHashReturned() {
+        when(menuItem.getPage()).thenReturn(null);
+        when(menuItem.getHstLink()).thenReturn(null);
+        when(menuItem.getExternalLink()).thenReturn(null);
+
+        assertEquals(HASHTAG, UrlResolver.getUrl(menuItem));
+    }
+
+    @Test
+    void When_GetUrl_WithNullItem_ExpectHashReturned() {
+        assertEquals(HASHTAG, UrlResolver.getUrl(null));
+    }
+}


### PR DESCRIPTION
This should now be complete as labels are retrievable within the `ResourceBundleService.java` Spring bean, a refactoring pull-request should follow at some point as I have identified a few improvements around this.

For now, this PR migrates the following into static utility methods:
* `addParameter` has been relocated to `utils` / `UrlParameterAppender.java`
* `escapeJSON` has been relocated to `utils` / `JsonEscaper.java`
* `getUrl` has been relocated to `utils` / `UrlResolver.java`

These other helper methods can be ignored:
* `label`
* `optionalLabel`
* `property`
* `labelFallback`
* `productSearch`