### PR TITLE
DS-965 - Development-data move sandbox/site-search-results to /site-search-results

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local---business-support-hub.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/configuration/local---business-support-hub.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: c1ca6026-0585-466d-a72b-c4202da2bf95
   hippo:name: Local/Feature - Business Support Hub
-  hippo:versionHistory: ed105e81-4b75-4f28-921a-54abbcd42e0e
+  hippo:versionHistory: 8286a1fe-d0d2-4863-a039-c3cb2504111c
   /local---business-support-hub[1]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:versionable']
@@ -13,14 +13,14 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2024-04-29T14:00:24.028+01:00
-    hippostdpubwf:lastModificationDate: 2024-12-09T14:59:59.613Z
+    hippostdpubwf:lastModificationDate: 2025-01-27T12:39:48.252Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', '', '', '', '']
     resourcebundle:id: bsh.local.config
     resourcebundle:keys: [gtm.is-production, gtm.container-id, gtm.preview-query-string,
       site-id, links.download.extensions, global-search.path]
     resourcebundle:messages: ['false', GTM-T7G4TNR, '&gtm_auth=PCWhL-3fHI0sM_2ztUYr6g&gtm_preview=env-126&gtm_cookies_win=x',
-      bsh, 'pdf,docx,xlsx,jpg,jpeg,png,eps,svg', /sandbox/site-search-results]
+      bsh, 'pdf,docx,xlsx,jpg,jpeg,png,eps,svg', /site-search-results]
   /local---business-support-hub[2]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -28,17 +28,16 @@
     hippo:availability: []
     hippostd:retainable: false
     hippostd:state: draft
-    hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2024-04-29T14:00:24.028+01:00
-    hippostdpubwf:lastModificationDate: 2024-12-09T15:14:41.076Z
+    hippostdpubwf:lastModificationDate: 2025-01-27T12:39:20.295Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['', '', '', '', '', '']
     resourcebundle:id: bsh.local.config
     resourcebundle:keys: [gtm.is-production, gtm.container-id, gtm.preview-query-string,
       site-id, links.download.extensions, global-search.path]
     resourcebundle:messages: ['false', GTM-T7G4TNR, '&gtm_auth=PCWhL-3fHI0sM_2ztUYr6g&gtm_preview=env-126&gtm_cookies_win=x',
-      bsh, 'pdf,docx,xlsx,jpg,jpeg,png,eps,svg', /sandbox/site-search-results]
+      bsh, 'pdf,docx,xlsx,jpg,jpeg,png,eps,svg', /site-search-results]
   /local---business-support-hub[3]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -48,12 +47,12 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2024-04-29T14:00:24.028+01:00
-    hippostdpubwf:lastModificationDate: 2024-12-09T14:59:59.613Z
+    hippostdpubwf:lastModificationDate: 2025-01-27T12:39:48.252Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2024-12-09T15:00:06.870Z
+    hippostdpubwf:publicationDate: 2025-01-27T12:39:52.133Z
     resourcebundle:descriptions: ['', '', '', '', '', '']
     resourcebundle:id: bsh.local.config
     resourcebundle:keys: [gtm.is-production, gtm.container-id, gtm.preview-query-string,
       site-id, links.download.extensions, global-search.path]
     resourcebundle:messages: ['false', GTM-T7G4TNR, '&gtm_auth=PCWhL-3fHI0sM_2ztUYr6g&gtm_preview=env-126&gtm_cookies_win=x',
-      bsh, 'pdf,docx,xlsx,jpg,jpeg,png,eps,svg', /sandbox/site-search-results]
+      bsh, 'pdf,docx,xlsx,jpg,jpeg,png,eps,svg', /site-search-results]

--- a/repository-data/development/src/main/resources/hcm-content/content/assets/business-support-hub.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/assets/business-support-hub.yaml
@@ -1,0 +1,7 @@
+/content/assets/business-support-hub:
+  jcr:primaryType: hippogallery:stdAssetGallery
+  jcr:mixinTypes: ['hippo:named', 'mix:versionable']
+  jcr:uuid: fd9c1f1b-4c12-4026-b25d-76fc108dbe21
+  hippo:name: Business Support Hub
+  hippostd:foldertype: [new-file-folder]
+  hippostd:gallerytype: ['hippogallery:exampleAssetSet']

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/bsh/sandbox.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/bsh/sandbox.yaml
@@ -227,13 +227,13 @@
         hippostd:foldertype: [new-translated-folder-shared-bsh, new-shared-bsh-document]
         hippotranslation:id: 2e3bede1-e33a-4889-92a1-21f92eaaedf3
         hippotranslation:locale: en
-        /visitscotland.com:
+        /scot.gov:
           jcr:primaryType: hippo:handle
           jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
           jcr:uuid: 8b9e387c-24d2-4e0c-ba4b-4dac823c8e57
-          hippo:name: VisitScotland.com
-          hippo:versionHistory: f72bc946-72ab-49aa-b7fd-9985c15d212d
-          /visitscotland.com[1]:
+          hippo:name: The Scottish Government
+          hippo:versionHistory: a954bfe7-0721-4c53-97b6-f272f42f19c7
+          /scot.gov[1]:
             jcr:primaryType: visitscotland:SharedLinkBSH
             jcr:mixinTypes: ['mix:referenceable']
             jcr:uuid: 3e59e236-64c6-40c8-95ba-12b3f0c10e95
@@ -242,18 +242,17 @@
             hippostd:state: draft
             hippostdpubwf:createdBy: admin
             hippostdpubwf:creationDate: 2024-09-25T17:01:40.525+01:00
-            hippostdpubwf:lastModificationDate: 2024-12-04T20:49:29.407Z
+            hippostdpubwf:lastModificationDate: 2025-01-27T13:40:06.685Z
             hippostdpubwf:lastModifiedBy: admin
             hippotranslation:id: 21068f6f-5c67-40f9-b574-58fd79ed6f81
             hippotranslation:locale: en
             visitscotland:regions: []
             visitscotland:sectors: []
             visitscotland:skill: ''
-            visitscotland:source: Scotland Tourism Board
-            visitscotland:teaser: Get all the information you need for your trip to
-              Scotland! Book accommodation, discover new places to visit, find amazing
-              things to do and more!
-            visitscotland:title: VisitScotland Consumer Website
+            visitscotland:source: ''
+            visitscotland:teaser: Scotland’s Digital Future – A Strategy for Scotland.
+              Updates from the Digital Directorate.
+            visitscotland:title: The Scottish Government
             visitscotland:topic: []
             visitscotland:type: ''
             visitscotland:types: []
@@ -267,8 +266,8 @@
             /visitscotland:linkTypes:
               jcr:primaryType: visitscotland:ExternalLink
               visitscotland:label: ''
-              visitscotland:link: https://www.visitscotland.com
-          /visitscotland.com[2]:
+              visitscotland:link: https://www.gov.scot/
+          /scot.gov[2]:
             jcr:primaryType: visitscotland:SharedLinkBSH
             jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
             jcr:uuid: f0ea80a6-ad7d-4221-8f49-3fd8a6debafd
@@ -277,18 +276,17 @@
             hippostd:state: unpublished
             hippostdpubwf:createdBy: admin
             hippostdpubwf:creationDate: 2024-09-25T17:01:40.525+01:00
-            hippostdpubwf:lastModificationDate: 2024-12-04T20:49:27.886Z
+            hippostdpubwf:lastModificationDate: 2025-01-27T13:42:12.606Z
             hippostdpubwf:lastModifiedBy: admin
             hippotranslation:id: 21068f6f-5c67-40f9-b574-58fd79ed6f81
             hippotranslation:locale: en
             visitscotland:regions: []
             visitscotland:sectors: []
             visitscotland:skill: ''
-            visitscotland:source: Scotland Tourism Board
-            visitscotland:teaser: Get all the information you need for your trip to
-              Scotland! Book accommodation, discover new places to visit, find amazing
-              things to do and more!
-            visitscotland:title: VisitScotland Consumer Website
+            visitscotland:source: ''
+            visitscotland:teaser: Scotland’s Digital Future – A Strategy for Scotland.
+              Updates from the Digital Directorate.
+            visitscotland:title: The Scottish Government
             visitscotland:topic: []
             visitscotland:type: ''
             visitscotland:types: []
@@ -302,8 +300,8 @@
             /visitscotland:linkTypes:
               jcr:primaryType: visitscotland:ExternalLink
               visitscotland:label: ''
-              visitscotland:link: https://www.visitscotland.com
-          /visitscotland.com[3]:
+              visitscotland:link: https://www.gov.scot/
+          /scot.gov[3]:
             jcr:primaryType: visitscotland:SharedLinkBSH
             jcr:mixinTypes: ['mix:referenceable']
             jcr:uuid: 65105c4d-8fb3-48ee-9ca7-996ae1c05c28
@@ -312,19 +310,22 @@
             hippostd:state: published
             hippostdpubwf:createdBy: admin
             hippostdpubwf:creationDate: 2024-09-25T17:01:40.525+01:00
-            hippostdpubwf:lastModificationDate: 2024-09-25T17:03:12.988+01:00
+            hippostdpubwf:lastModificationDate: 2025-01-27T13:42:12.606Z
             hippostdpubwf:lastModifiedBy: admin
-            hippostdpubwf:publicationDate: 2024-09-25T17:03:16.030+01:00
+            hippostdpubwf:publicationDate: 2025-01-27T13:44:22.377Z
             hippotranslation:id: 21068f6f-5c67-40f9-b574-58fd79ed6f81
             hippotranslation:locale: en
+            visitscotland:regions: []
             visitscotland:sectors: []
             visitscotland:skill: ''
-            visitscotland:source: Scotland Tourism Board
-            visitscotland:teaser: Get all the information you need for your trip to
-              Scotland! Book accommodation, discover new places to visit, find amazing
-              things to do and more!
-            visitscotland:title: VisitScotland Consumer Website
+            visitscotland:source: ''
+            visitscotland:teaser: Scotland’s Digital Future – A Strategy for Scotland.
+              Updates from the Digital Directorate.
+            visitscotland:title: The Scottish Government
+            visitscotland:topic: []
+            visitscotland:type: ''
             visitscotland:types: []
+            visitscotland:websiteType: external
             /visitscotland:image:
               jcr:primaryType: hippogallerypicker:imagelink
               hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
@@ -334,7 +335,7 @@
             /visitscotland:linkTypes:
               jcr:primaryType: visitscotland:ExternalLink
               visitscotland:label: ''
-              visitscotland:link: https://www.visitscotland.com
+              visitscotland:link: https://www.gov.scot/
       /download-links:
         jcr:primaryType: hippostd:folder
         jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/bsh/sandbox.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/bsh/sandbox.yaml
@@ -16055,7 +16055,7 @@
         jcr:primaryType: hippostd:folder
         jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
         jcr:uuid: 4cd0f3b9-41c9-46f1-ada9-d13036f64e98
-        hippo:name: SCRM (Data Stack) - ??
+        hippo:name: SCRM (Data Stack) - BSH Enquiry
         hippostd:foldertype: [new-bsh-folder, new-bsh-page, new-bsh-module]
         hippotranslation:id: cab85378-c858-43df-892b-98b2bb58af53
         hippotranslation:locale: en
@@ -16182,7 +16182,7 @@
           jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
           jcr:uuid: 8bd130c8-69c5-4d76-b197-e94aa0b4861d
           hippo:name: SCRM / Data processing Form
-          hippo:versionHistory: 2ccbe351-ec9e-465b-840c-49023155835c
+          hippo:versionHistory: 99841cb1-093b-438e-9047-9d082f34c132
           /scrm---data-processing-form[1]:
             jcr:primaryType: visitscotland:Form
             jcr:mixinTypes: ['mix:versionable']
@@ -16192,7 +16192,7 @@
             hippostd:state: unpublished
             hippostdpubwf:createdBy: admin
             hippostdpubwf:creationDate: 2024-11-28T15:19:16.974Z
-            hippostdpubwf:lastModificationDate: 2024-12-09T11:59:15.351Z
+            hippostdpubwf:lastModificationDate: 2025-01-27T12:47:08.695Z
             hippostdpubwf:lastModifiedBy: admin
             hippotranslation:id: 29e33ab9-c95f-471d-82ed-48f1973a32a2
             hippotranslation:locale: en
@@ -16203,7 +16203,7 @@
             /visitscotland:form:
               jcr:primaryType: visitscotland:FormCompoundCRM
               visitscotland:jsonURL: https://static.visitscotland.com/forms/enquiries/business-support-enquiries.json
-              visitscotland:url: http://172.29.25.17:9080/api/support/enquiry
+              visitscotland:url: https://api.visitscotland.com/test/submit/dp-forms/support/enquiry
           /scrm---data-processing-form[2]:
             jcr:primaryType: visitscotland:Form
             jcr:mixinTypes: ['mix:referenceable']
@@ -16213,7 +16213,7 @@
             hippostd:state: draft
             hippostdpubwf:createdBy: admin
             hippostdpubwf:creationDate: 2024-11-28T15:19:16.974Z
-            hippostdpubwf:lastModificationDate: 2024-12-09T11:59:06.124Z
+            hippostdpubwf:lastModificationDate: 2025-01-27T12:46:44.128Z
             hippostdpubwf:lastModifiedBy: admin
             hippotranslation:id: 29e33ab9-c95f-471d-82ed-48f1973a32a2
             hippotranslation:locale: en
@@ -16224,7 +16224,7 @@
             /visitscotland:form:
               jcr:primaryType: visitscotland:FormCompoundCRM
               visitscotland:jsonURL: https://static.visitscotland.com/forms/enquiries/business-support-enquiries.json
-              visitscotland:url: http://172.29.25.17:9080/api/support/enquiry
+              visitscotland:url: https://api.visitscotland.com/test/submit/dp-forms/support/enquiry
           /scrm---data-processing-form[3]:
             jcr:primaryType: visitscotland:Form
             jcr:mixinTypes: ['mix:referenceable']
@@ -16234,9 +16234,9 @@
             hippostd:state: published
             hippostdpubwf:createdBy: admin
             hippostdpubwf:creationDate: 2024-11-28T15:19:16.974Z
-            hippostdpubwf:lastModificationDate: 2024-12-09T11:59:15.351Z
+            hippostdpubwf:lastModificationDate: 2025-01-27T12:47:08.695Z
             hippostdpubwf:lastModifiedBy: admin
-            hippostdpubwf:publicationDate: 2024-12-09T11:59:19.472Z
+            hippostdpubwf:publicationDate: 2025-01-27T12:47:17.875Z
             hippotranslation:id: 29e33ab9-c95f-471d-82ed-48f1973a32a2
             hippotranslation:locale: en
             visitscotland:nonJavaScriptMessage: Please, activate JavaScript to make
@@ -16246,7 +16246,7 @@
             /visitscotland:form:
               jcr:primaryType: visitscotland:FormCompoundCRM
               visitscotland:jsonURL: https://static.visitscotland.com/forms/enquiries/business-support-enquiries.json
-              visitscotland:url: http://172.29.25.17:9080/api/support/enquiry
+              visitscotland:url: https://api.visitscotland.com/test/submit/dp-forms/support/enquiry
   /features:
     jcr:primaryType: hippostd:folder
     jcr:mixinTypes: ['hippotranslation:translated', 'mix:versionable']
@@ -19131,128 +19131,3 @@
     hippostd:foldertype: [new-translated-folder, new-document]
     hippotranslation:id: a6cff355-cfae-49a3-abe8-aa2f45ad230d
     hippotranslation:locale: en
-  /site-search-results:
-    jcr:primaryType: hippostd:folder
-    jcr:mixinTypes: ['hippotranslation:translated', 'mix:versionable']
-    jcr:uuid: 950545d6-0836-46be-b2bc-d6e3c47cc259
-    hippostd:foldertype: [new-bsh-folder, new-bsh-page, new-bsh-module]
-    hippotranslation:id: 387ec8a1-c9c3-4fbe-8731-405c480963c8
-    hippotranslation:locale: en
-    /content:
-      jcr:primaryType: hippo:handle
-      jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
-      jcr:uuid: f30ad8c7-2eea-41b7-aebc-03cf4c261107
-      hippo:name: Search results
-      hippo:versionHistory: 1b43d945-bb9e-4b44-b719-a489f6ff4d7f
-      /content[1]:
-        jcr:primaryType: visitscotland:GeneralBSH
-        jcr:mixinTypes: ['mix:referenceable']
-        jcr:uuid: f54ad27c-afaa-4719-b989-1ff286e151a6
-        hippo:availability: []
-        hippostd:retainable: false
-        hippostd:state: draft
-        hippostdpubwf:createdBy: admin
-        hippostdpubwf:creationDate: 2024-12-09T15:03:44.994Z
-        hippostdpubwf:lastModificationDate: 2024-12-09T15:14:14.479Z
-        hippostdpubwf:lastModifiedBy: admin
-        hippotranslation:id: a45d2aef-2a61-4e3d-ab29-08b837bfcf97
-        hippotranslation:locale: en
-        visitscotland:breadcrumb: ''
-        visitscotland:hideNewsletter: true
-        visitscotland:publishDate: 0001-01-01T12:00:00Z
-        visitscotland:readingTime: 0
-        visitscotland:regions: []
-        visitscotland:sectors: []
-        visitscotland:seoDescription: Search results
-        visitscotland:seoNoIndex: true
-        visitscotland:seoTitle: Search results
-        visitscotland:skill: ''
-        visitscotland:teaser: Search results
-        visitscotland:theme: simple
-        visitscotland:title: Search results
-        visitscotland:topic: []
-        visitscotland:type: ''
-        /visitscotland:heroImage:
-          jcr:primaryType: hippogallerypicker:imagelink
-          hippo:docbase: a5b5922e-d0d5-420c-af2d-670768cf7bd6
-          hippo:facets: []
-          hippo:modes: []
-          hippo:values: []
-        /visitscotland:introduction:
-          jcr:primaryType: hippostd:html
-          hippostd:content: <p>Search results</p>
-      /content[2]:
-        jcr:primaryType: visitscotland:GeneralBSH
-        jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
-        jcr:uuid: 9d1a10fb-64d1-49a9-affd-c7c137c25b2f
-        hippo:availability: [preview]
-        hippostd:retainable: false
-        hippostd:state: unpublished
-        hippostdpubwf:createdBy: admin
-        hippostdpubwf:creationDate: 2024-12-09T15:03:44.994Z
-        hippostdpubwf:lastModificationDate: 2024-12-09T15:14:24.235Z
-        hippostdpubwf:lastModifiedBy: admin
-        hippotranslation:id: a45d2aef-2a61-4e3d-ab29-08b837bfcf97
-        hippotranslation:locale: en
-        visitscotland:breadcrumb: ''
-        visitscotland:hideNewsletter: true
-        visitscotland:publishDate: 0001-01-01T12:00:00Z
-        visitscotland:readingTime: 0
-        visitscotland:regions: []
-        visitscotland:sectors: []
-        visitscotland:seoDescription: Search results
-        visitscotland:seoNoIndex: true
-        visitscotland:seoTitle: Search results
-        visitscotland:skill: ''
-        visitscotland:teaser: Search results
-        visitscotland:theme: simple
-        visitscotland:title: Search results
-        visitscotland:topic: []
-        visitscotland:type: ''
-        /visitscotland:heroImage:
-          jcr:primaryType: hippogallerypicker:imagelink
-          hippo:docbase: a5b5922e-d0d5-420c-af2d-670768cf7bd6
-          hippo:facets: []
-          hippo:modes: []
-          hippo:values: []
-        /visitscotland:introduction:
-          jcr:primaryType: hippostd:html
-          hippostd:content: <p>Search results</p>
-      /content[3]:
-        jcr:primaryType: visitscotland:GeneralBSH
-        jcr:mixinTypes: ['mix:referenceable']
-        jcr:uuid: 0573d5e0-c732-44f2-bc95-dd3050648c81
-        hippo:availability: [live]
-        hippostd:retainable: false
-        hippostd:state: published
-        hippostdpubwf:createdBy: admin
-        hippostdpubwf:creationDate: 2024-12-09T15:03:44.994Z
-        hippostdpubwf:lastModificationDate: 2024-12-09T15:14:24.235Z
-        hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2024-12-09T15:14:28.246Z
-        hippotranslation:id: a45d2aef-2a61-4e3d-ab29-08b837bfcf97
-        hippotranslation:locale: en
-        visitscotland:breadcrumb: ''
-        visitscotland:hideNewsletter: true
-        visitscotland:publishDate: 0001-01-01T12:00:00Z
-        visitscotland:readingTime: 0
-        visitscotland:regions: []
-        visitscotland:sectors: []
-        visitscotland:seoDescription: Search results
-        visitscotland:seoNoIndex: true
-        visitscotland:seoTitle: Search results
-        visitscotland:skill: ''
-        visitscotland:teaser: Search results
-        visitscotland:theme: simple
-        visitscotland:title: Search results
-        visitscotland:topic: []
-        visitscotland:type: ''
-        /visitscotland:heroImage:
-          jcr:primaryType: hippogallerypicker:imagelink
-          hippo:docbase: a5b5922e-d0d5-420c-af2d-670768cf7bd6
-          hippo:facets: []
-          hippo:modes: []
-          hippo:values: []
-        /visitscotland:introduction:
-          jcr:primaryType: hippostd:html
-          hippostd:content: <p>Search results</p>

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/bsh/site.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/bsh/site.yaml
@@ -145,3 +145,128 @@
           <p>For years Scotland has welcomed the world's greatest thinkers, pioneers, innovators and leaders to the many international congresses, conferences and meetings we host. Scotland is an incredible destination for business events. Our world leading academia, research institutes, industries and innovation centres thrive on ideas, new challenges and the inspiration we can give and draw from delegates to our country.</p>
 
           <p>In Scotland we believe business events are a catalyst for social and economic transformation; they are a driver to tackle climate change; they are a voice for human rights; they are a leader in the global <a href="https://businessevents.visitscotland.com/why-scotland/journey-to-change/" title="Journey to change">Journey to Change</a>.</p>
+  /site-search-results:
+    jcr:primaryType: hippostd:folder
+    jcr:mixinTypes: ['hippotranslation:translated', 'mix:versionable']
+    jcr:uuid: 950545d6-0836-46be-b2bc-d6e3c47cc259
+    hippostd:foldertype: [new-bsh-folder, new-bsh-page, new-bsh-module]
+    hippotranslation:id: 387ec8a1-c9c3-4fbe-8731-405c480963c8
+    hippotranslation:locale: en
+    /content:
+      jcr:primaryType: hippo:handle
+      jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+      jcr:uuid: f30ad8c7-2eea-41b7-aebc-03cf4c261107
+      hippo:name: Search results
+      hippo:versionHistory: 1b43d945-bb9e-4b44-b719-a489f6ff4d7f
+      /content[1]:
+        jcr:primaryType: visitscotland:GeneralBSH
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: f54ad27c-afaa-4719-b989-1ff286e151a6
+        hippo:availability: []
+        hippostd:retainable: false
+        hippostd:state: draft
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2024-12-09T15:03:44.994Z
+        hippostdpubwf:lastModificationDate: 2024-12-09T15:14:14.479Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: a45d2aef-2a61-4e3d-ab29-08b837bfcf97
+        hippotranslation:locale: en
+        visitscotland:breadcrumb: ''
+        visitscotland:hideNewsletter: true
+        visitscotland:publishDate: 0001-01-01T12:00:00Z
+        visitscotland:readingTime: 0
+        visitscotland:regions: []
+        visitscotland:sectors: []
+        visitscotland:seoDescription: Search results
+        visitscotland:seoNoIndex: true
+        visitscotland:seoTitle: Search results
+        visitscotland:skill: ''
+        visitscotland:teaser: Search results
+        visitscotland:theme: simple
+        visitscotland:title: Search results
+        visitscotland:topic: []
+        visitscotland:type: ''
+        /visitscotland:heroImage:
+          jcr:primaryType: hippogallerypicker:imagelink
+          hippo:docbase: a5b5922e-d0d5-420c-af2d-670768cf7bd6
+          hippo:facets: []
+          hippo:modes: []
+          hippo:values: []
+        /visitscotland:introduction:
+          jcr:primaryType: hippostd:html
+          hippostd:content: <p>Search results</p>
+      /content[2]:
+        jcr:primaryType: visitscotland:GeneralBSH
+        jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+        jcr:uuid: 9d1a10fb-64d1-49a9-affd-c7c137c25b2f
+        hippo:availability: [preview]
+        hippostd:retainable: false
+        hippostd:state: unpublished
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2024-12-09T15:03:44.994Z
+        hippostdpubwf:lastModificationDate: 2024-12-09T15:14:24.235Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: a45d2aef-2a61-4e3d-ab29-08b837bfcf97
+        hippotranslation:locale: en
+        visitscotland:breadcrumb: ''
+        visitscotland:hideNewsletter: true
+        visitscotland:publishDate: 0001-01-01T12:00:00Z
+        visitscotland:readingTime: 0
+        visitscotland:regions: []
+        visitscotland:sectors: []
+        visitscotland:seoDescription: Search results
+        visitscotland:seoNoIndex: true
+        visitscotland:seoTitle: Search results
+        visitscotland:skill: ''
+        visitscotland:teaser: Search results
+        visitscotland:theme: simple
+        visitscotland:title: Search results
+        visitscotland:topic: []
+        visitscotland:type: ''
+        /visitscotland:heroImage:
+          jcr:primaryType: hippogallerypicker:imagelink
+          hippo:docbase: a5b5922e-d0d5-420c-af2d-670768cf7bd6
+          hippo:facets: []
+          hippo:modes: []
+          hippo:values: []
+        /visitscotland:introduction:
+          jcr:primaryType: hippostd:html
+          hippostd:content: <p>Search results</p>
+      /content[3]:
+        jcr:primaryType: visitscotland:GeneralBSH
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 0573d5e0-c732-44f2-bc95-dd3050648c81
+        hippo:availability: [live]
+        hippostd:retainable: false
+        hippostd:state: published
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2024-12-09T15:03:44.994Z
+        hippostdpubwf:lastModificationDate: 2024-12-09T15:14:24.235Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippostdpubwf:publicationDate: 2024-12-09T15:14:28.246Z
+        hippotranslation:id: a45d2aef-2a61-4e3d-ab29-08b837bfcf97
+        hippotranslation:locale: en
+        visitscotland:breadcrumb: ''
+        visitscotland:hideNewsletter: true
+        visitscotland:publishDate: 0001-01-01T12:00:00Z
+        visitscotland:readingTime: 0
+        visitscotland:regions: []
+        visitscotland:sectors: []
+        visitscotland:seoDescription: Search results
+        visitscotland:seoNoIndex: true
+        visitscotland:seoTitle: Search results
+        visitscotland:skill: ''
+        visitscotland:teaser: Search results
+        visitscotland:theme: simple
+        visitscotland:title: Search results
+        visitscotland:topic: []
+        visitscotland:type: ''
+        /visitscotland:heroImage:
+          jcr:primaryType: hippogallerypicker:imagelink
+          hippo:docbase: a5b5922e-d0d5-420c-af2d-670768cf7bd6
+          hippo:facets: []
+          hippo:modes: []
+          hippo:values: []
+        /visitscotland:introduction:
+          jcr:primaryType: hippostd:html
+          hippostd:content: <p>Search results</p>


### PR DESCRIPTION
Hello Guys, 

Due to some limitations in the Cludo SDK, we need to move the Cludo Search Results page to the same location that we need to use in the production environment. This will only affect development-data so we are ok to go with this.

I have also used this opportunity to fix the URL on the SCRM :)

JIRA: https://visitscotland.atlassian.net/browse/DS-965