### PR TITLE
DS-1025 - Fix bug when setting contact details on Travel Trade Events

### DIFF
--- a/site/components/src/main/java/com/visitscotland/brxm/rest/event/EventCardFactory.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/rest/event/EventCardFactory.java
@@ -74,7 +74,7 @@ public class EventCardFactory {
             card.setRegistrationDeadline(fullDateFormat.format(deadlineCalendar.getTime()));
         }
 
-        card.setContact(document.getContentType());
+        card.setContact(document.getEmail());
     }
 
     private String formatDates(EventBSH document, EventCard card) {


### PR DESCRIPTION
The way that this is currently implemented makes unit testing difficult - coverage will be added as part of DS-1024 when concerns are separated and single responsibility principle followed. For now, QA must verify.