### PR TITLE
BSHUB-627 - `EventDateValidator.java` forces the end-user to enter a date for an optional date.

### DIFF
--- a/cms/src/main/java/com/visitscotland/brxm/validator/EventDateValidator.java
+++ b/cms/src/main/java/com/visitscotland/brxm/validator/EventDateValidator.java
@@ -15,6 +15,7 @@ import javax.jcr.Node;
 
 import java.util.Calendar;
 import java.util.Optional;
+import java.util.TimeZone;
 
 /**
  * jcrType = visitscotland:event-date-validator
@@ -41,6 +42,18 @@ public class EventDateValidator implements Validator<Node> {
     private boolean isEndDateAfterStartDate(final Node node) throws RepositoryException {
         final Calendar startDate = getStartDate(node);
         final Calendar endDate = getEndDate(node);
+
+
+        final Calendar defaultDate = new Calendar.Builder()
+            .setCalendarType("gregory")
+            .setDate(1, 1, 1)
+            .setTimeOfDay(12, 0, 0)
+            .setTimeZone(TimeZone.getTimeZone("UTC"))
+            .build();
+
+        if(endDate.equals(defaultDate)) {
+            return true;
+        }
 
         return endDate.after(startDate);
     }

--- a/cms/src/test/java/com/visitscotland/brxm/validator/EventDateValidatorTest.java
+++ b/cms/src/test/java/com/visitscotland/brxm/validator/EventDateValidatorTest.java
@@ -1,5 +1,6 @@
 package com.visitscotland.brxm.validator;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +20,8 @@ import javax.jcr.Property;
 import javax.jcr.Node;
 
 import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,6 +67,24 @@ class EventDateValidatorTest {
         verify(node, times(1)).getProperty(eq(START_DATE_PROPERTY));
         verify(node, times(1)).getProperty(eq(END_DATE_PROPERTY));
         verify(endDate, times(1)).after(any(Calendar.class));
+    }
+
+    @Test
+    void validate_EventNodeWithDefaultEndDateAndValidStartDate_EmptyOptional() throws RepositoryException {
+        final Calendar startDate = Calendar.getInstance();
+        final Calendar endDate = new Calendar.Builder()
+            .setCalendarType("gregory")
+            .setDate(1, 1, 1)
+            .setTimeOfDay(12, 0, 0)
+            .setTimeZone(TimeZone.getTimeZone("UTC"))
+            .build();
+
+        stubNodeProperty(START_DATE_PROPERTY, startDate);
+        stubNodeProperty(END_DATE_PROPERTY, endDate);
+
+        final var result = eventDateValidator.validate(validationContext, node);
+
+        Assertions.assertTrue(result.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
It has been discovered that brXM defaults optional dates to 0001-01-01T12:00:00.000Z. The EventDateValidator.java retrieves the start and end dates of an event and checks whether the end date is after the start date. However, since the end date is an optional field in the CMS and defaults to 0001-01-01T12:00:00.000Z, this validation fails when a user enters an event without specifying an end date.