### PR TITLE
DS-1132 Solve issue with Calendar Dates and Time Zones

### DIFF
--- a/site/components/src/main/java/com/visitscotland/brxm/event/EventCardFactory.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/event/EventCardFactory.java
@@ -12,18 +12,30 @@ import org.springframework.stereotype.Component;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.TimeZone;
 
 @Component
 public class EventCardFactory {
 
     private static final String BUNDLE = "events-listings";
-    private static final SimpleDateFormat dayMonthFormat = new SimpleDateFormat("dd MMM");
-    private static final SimpleDateFormat fullDateFormat = new SimpleDateFormat("dd MMM, yyyy");
+    private static final SimpleDateFormat dayMonthFormat = createDateFormat("dd MMM");
+    private static final SimpleDateFormat fullDateFormat = createDateFormat("dd MMM, yyyy");
     private static final Locale LOCALE = Locale.UK;
 
     private final ResourceBundleService bundle;
     private final PriceFormatter priceFormatter;
     private final ContentLogger contentLogger;
+
+    /**
+     * This method creates a SimpleDateFormat with the given format and sets the timezone to UTC to prevent the system
+     * time zone to affect the date formatting. <a href="https://visitscotland.atlassian.net/browse/DS-1132">
+     * See JIRA issue</a>
+     */
+    private static SimpleDateFormat createDateFormat(String format){
+        SimpleDateFormat dateFormat = new SimpleDateFormat(format);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat;
+    }
 
     protected EventCardFactory(ResourceBundleService bundle,
                             PriceFormatter priceFormatter,


### PR DESCRIPTION
It looks like the problem was related to the project using `Calendar` and `SimpleDateFormat` to format the dates.

Apparently, if we were using a more modern approach (`java.time`) we wouldn't have run into this issue. I don't think we can alter this as it is a platform feature but it would be nice to remember this for any other project

https://visitscotland.atlassian.net/browse/DS-1132