### PR TITLE
Remove warning for default label from the CMS

### DIFF
--- a/site/components/src/main/java/com/visitscotland/brxm/services/ResourceBundleService.java
+++ b/site/components/src/main/java/com/visitscotland/brxm/services/ResourceBundleService.java
@@ -53,14 +53,11 @@ public class ResourceBundleService {
         return getResourceBundle(bundleName, key, locale, false);
     }
 
-    public String getSiteResourceBundle(String bundleName, String key, Locale locale){
+    public String getSiteResourceBundle(String bundleName, String key, Locale locale) {
         if (!properties.getSiteId().isBlank() && hasSiteResourceBundle(bundleName, locale)) {
-	    final String bundleId = getSiteResourceBundleId(bundleName);
+            final String bundleId = getSiteResourceBundleId(bundleName);
             String value = getResourceBundle(bundleId, key, locale, true);
-            if (value == null) {
-                logger.warn("The key {} does not exist in the site resource bundle {} for locale {}", key,
-                        getSiteResourceBundleId(bundleName), locale);
-            } else {
+            if (value != null) {
                 return value;
             }
         }


### PR DESCRIPTION
I have removed this warning message which is no needed since we took the decision of fallbacking labels to dot-com. 

This PR does not need to be tested as it is not changing any logic apart from the disabling of the log message

https://visitscotland.atlassian.net/browse/DS-1166