### PR TITLE
Prevent Error when branches have been merged to develop during the release

### DIFF
--- a/ci/finish-release.bat
+++ b/ci/finish-release.bat
@@ -30,6 +30,32 @@ if errorlevel 1 (
   goto :EOF
 )
 
+:: Update main and develop branches
+echo echo "Updating main and develop branches"
+git checkout main
+if errorlevel 1 (
+  call :exit_on_failure "Checkout to main"
+  goto :EOF
+)
+
+git pull origin main
+if errorlevel 1 (
+  call :exit_on_failure "Pulling main"
+  goto :EOF
+)
+
+git checkout develop
+if errorlevel 1 (
+  call :exit_on_failure "Checkout to develop"
+  goto :EOF
+)
+
+git pull origin develop
+if errorlevel 1 (
+  call :exit_on_failure "Pulling develop"
+  goto :EOF
+)
+
 :: Checkout to the release branch
 echo Checking out the release branch %releaseBranch%
 git checkout "%releaseBranch%"

--- a/ci/finish-release.bat
+++ b/ci/finish-release.bat
@@ -31,7 +31,7 @@ if errorlevel 1 (
 )
 
 :: Update main and develop branches
-echo echo "Updating main and develop branches"
+echo "Updating main and develop branches"
 git checkout main
 if errorlevel 1 (
   call :exit_on_failure "Checkout to main"

--- a/ci/finish-release.sh
+++ b/ci/finish-release.sh
@@ -33,6 +33,24 @@ if [ -z "$releaseBranch" ]; then
     exit_on_failure "No release/* branch found. Git branch --list for release branches"
 fi
 
+echo "Updating main and develop branches"
+if ! git checkout main; then
+    exit_on_failure "Checkout to main"
+fi
+
+if ! git pull origin main; then
+    exit_on_failure "Pulling main"
+fi
+
+if ! git checkout develop; then
+    exit_on_failure "Checkout to develop"
+fi
+
+if ! git pull origin develop; then
+    exit_on_failure "Pulling develop"
+fi
+
+
 echo "Checking out the release branch $releaseBranch"
 if ! git checkout "$releaseBranch"; then
     exit_on_failure "Checkout to release branch"

--- a/ci/finish-release.sh
+++ b/ci/finish-release.sh
@@ -50,7 +50,6 @@ if ! git pull origin develop; then
     exit_on_failure "Pulling develop"
 fi
 
-
 echo "Checking out the release branch $releaseBranch"
 if ! git checkout "$releaseBranch"; then
     exit_on_failure "Checkout to release branch"


### PR DESCRIPTION
I had the following error during the release

`[ERROR] Failed to execute goal com.amashchenko.maven.plugin:gitflow-maven-plugin:1.21.0:release-finish (default-cli) on project dot-com-brxm: release-finish: Remote branch 'origin/develop' is ahead of the local branch 'develop'. Execute git pull. -> [Help 1]`

This error occurs when branches are merged into develop between the executions of `start-release.sh` and `finish-release.sh`. 

While working on this, I also added an update for the master branch. Although this feature may not be technically useful for CI/CD pipelines, it could be helpful in cases where one developer starts the release and another finishes it.

**Note: In case this chage were accepted it would need to be propagated to other projects**
**Note 2: I had the same issue in dot-org-brxm. We might have to look at this differently but not with vs-dms-products**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded our automated release process to ensure that all critical components are synchronized before deployment.
  - Implemented enhanced error handling to promptly address issues during releases, resulting in smoother, more stable updates for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->