### PR TITLE
Vs 425 listicle disclaimer message

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/modules/listicle.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/modules/listicle.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 0bc299e0-e93b-4204-baf9-152b58322341
   hippo:name: Listicle
-  hippo:versionHistory: 2511bcf6-0f74-46c4-b7b8-12f9f1f5e8db
+  hippo:versionHistory: c53203fd-e05a-4486-af8a-92f019ea35bd
   /listicle[1]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -14,18 +14,25 @@
     hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2025-05-22T16:08:36.786+01:00
-    hippostdpubwf:lastModificationDate: 2025-05-22T16:10:10.236+01:00
+    hippostdpubwf:lastModificationDate: 2025-05-27T12:28:31.286+01:00
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['']
     resourcebundle:id: listicle
     resourcebundle:keys: [listicle.disclaimer]
     resourcebundle:messages: [The following list was created by VisitScotland to showcase
         a range of experiences. It isn’t ranked in any specific order.]
-    resourcebundle:messages_de: ['']
-    resourcebundle:messages_es: ['']
-    resourcebundle:messages_fr: ['']
-    resourcebundle:messages_it: ['']
-    resourcebundle:messages_nl: ['']
+    resourcebundle:messages_de: ['Die folgende Liste wurde von VisitScotland erstellt,
+        um eine Auswahl an Erlebnissen zu präsentieren. Sie sind in keiner bestimmten
+        Reihenfolge aufgelistet.']
+    resourcebundle:messages_es: [La siguiente lista ha sido elaborada por VisitScotland
+        para mostrar una amplia gama de experiencias. No responde a un orden o clasificación
+        establecidos.]
+    resourcebundle:messages_fr: [La liste suivante a été créée par VisitScotland afin
+        de présenter différentes expériences et n’est classée dans aucun ordre particulier.]
+    resourcebundle:messages_it: [La seguente lista è stata creata da VisitScotland
+        per mettere in evidenza un mix di esperienze. Non c'è un ordine particolare.]
+    resourcebundle:messages_nl: [De onderstaande lijst is door VisitScotland gemaakt
+        om een aantal ervaringen te laten zien. Het staat niet in een bepaalde volgorde.]
   /listicle[2]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -36,18 +43,25 @@
     hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2025-05-22T16:08:36.786+01:00
-    hippostdpubwf:lastModificationDate: 2025-05-22T16:09:50.339+01:00
+    hippostdpubwf:lastModificationDate: 2025-05-27T12:29:10.309+01:00
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: ['']
     resourcebundle:id: listicle
     resourcebundle:keys: [listicle.disclaimer]
     resourcebundle:messages: [The following list was created by VisitScotland to showcase
         a range of experiences. It isn’t ranked in any specific order.]
-    resourcebundle:messages_de: ['']
-    resourcebundle:messages_es: ['']
-    resourcebundle:messages_fr: ['']
-    resourcebundle:messages_it: ['']
-    resourcebundle:messages_nl: ['']
+    resourcebundle:messages_de: ['Die folgende Liste wurde von VisitScotland erstellt,
+        um eine Auswahl an Erlebnissen zu präsentieren. Sie sind in keiner bestimmten
+        Reihenfolge aufgelistet.']
+    resourcebundle:messages_es: [La siguiente lista ha sido elaborada por VisitScotland
+        para mostrar una amplia gama de experiencias. No responde a un orden o clasificación
+        establecidos.]
+    resourcebundle:messages_fr: [La liste suivante a été créée par VisitScotland afin
+        de présenter différentes expériences et n’est classée dans aucun ordre particulier.]
+    resourcebundle:messages_it: [La seguente lista è stata creata da VisitScotland
+        per mettere in evidenza un mix di esperienze. Non c'è un ordine particolare.]
+    resourcebundle:messages_nl: [De onderstaande lijst is door VisitScotland gemaakt
+        om een aantal ervaringen te laten zien. Het staat niet in een bepaalde volgorde.]
   /listicle[3]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -58,16 +72,23 @@
     hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2025-05-22T16:08:36.786+01:00
-    hippostdpubwf:lastModificationDate: 2025-05-22T16:09:50.339+01:00
+    hippostdpubwf:lastModificationDate: 2025-05-27T12:29:10.309+01:00
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2025-05-22T16:10:32.419+01:00
+    hippostdpubwf:publicationDate: 2025-05-27T12:29:14.335+01:00
     resourcebundle:descriptions: ['']
     resourcebundle:id: listicle
     resourcebundle:keys: [listicle.disclaimer]
     resourcebundle:messages: [The following list was created by VisitScotland to showcase
         a range of experiences. It isn’t ranked in any specific order.]
-    resourcebundle:messages_de: ['']
-    resourcebundle:messages_es: ['']
-    resourcebundle:messages_fr: ['']
-    resourcebundle:messages_it: ['']
-    resourcebundle:messages_nl: ['']
+    resourcebundle:messages_de: ['Die folgende Liste wurde von VisitScotland erstellt,
+        um eine Auswahl an Erlebnissen zu präsentieren. Sie sind in keiner bestimmten
+        Reihenfolge aufgelistet.']
+    resourcebundle:messages_es: [La siguiente lista ha sido elaborada por VisitScotland
+        para mostrar una amplia gama de experiencias. No responde a un orden o clasificación
+        establecidos.]
+    resourcebundle:messages_fr: [La liste suivante a été créée par VisitScotland afin
+        de présenter différentes expériences et n’est classée dans aucun ordre particulier.]
+    resourcebundle:messages_it: [La seguente lista è stata creata da VisitScotland
+        per mettere in evidenza un mix di esperienze. Non c'è un ordine particolare.]
+    resourcebundle:messages_nl: [De onderstaande lijst is door VisitScotland gemaakt
+        om een aantal ervaringen te laten zien. Het staat niet in een bepaalde volgorde.]

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/modules/listicle.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/modules/listicle.yaml
@@ -1,0 +1,73 @@
+/content/documents/administration/labels/modules/listicle:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+  jcr:uuid: 0bc299e0-e93b-4204-baf9-152b58322341
+  hippo:name: Listicle
+  hippo:versionHistory: 2511bcf6-0f74-46c4-b7b8-12f9f1f5e8db
+  /listicle[1]:
+    jcr:primaryType: resourcebundle:resourcebundle
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: 6dffdf0f-081d-4bed-92a2-99833f999824
+    hippo:availability: []
+    hippostd:retainable: false
+    hippostd:state: draft
+    hippostd:transferable: false
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2025-05-22T16:08:36.786+01:00
+    hippostdpubwf:lastModificationDate: 2025-05-22T16:10:10.236+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    resourcebundle:descriptions: ['']
+    resourcebundle:id: listicle
+    resourcebundle:keys: [listicle.disclaimer]
+    resourcebundle:messages: [The following list was created by VisitScotland to showcase
+        a range of experiences. It isn’t ranked in any specific order.]
+    resourcebundle:messages_de: ['']
+    resourcebundle:messages_es: ['']
+    resourcebundle:messages_fr: ['']
+    resourcebundle:messages_it: ['']
+    resourcebundle:messages_nl: ['']
+  /listicle[2]:
+    jcr:primaryType: resourcebundle:resourcebundle
+    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:uuid: bd4254b2-fef9-418a-9018-0c1e7376d273
+    hippo:availability: [preview]
+    hippostd:retainable: false
+    hippostd:state: unpublished
+    hippostd:transferable: false
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2025-05-22T16:08:36.786+01:00
+    hippostdpubwf:lastModificationDate: 2025-05-22T16:09:50.339+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    resourcebundle:descriptions: ['']
+    resourcebundle:id: listicle
+    resourcebundle:keys: [listicle.disclaimer]
+    resourcebundle:messages: [The following list was created by VisitScotland to showcase
+        a range of experiences. It isn’t ranked in any specific order.]
+    resourcebundle:messages_de: ['']
+    resourcebundle:messages_es: ['']
+    resourcebundle:messages_fr: ['']
+    resourcebundle:messages_it: ['']
+    resourcebundle:messages_nl: ['']
+  /listicle[3]:
+    jcr:primaryType: resourcebundle:resourcebundle
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: 2f2e41b8-ef6b-458a-bcc9-6d56a18a706d
+    hippo:availability: [live]
+    hippostd:retainable: false
+    hippostd:state: published
+    hippostd:transferable: false
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2025-05-22T16:08:36.786+01:00
+    hippostdpubwf:lastModificationDate: 2025-05-22T16:09:50.339+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2025-05-22T16:10:32.419+01:00
+    resourcebundle:descriptions: ['']
+    resourcebundle:id: listicle
+    resourcebundle:keys: [listicle.disclaimer]
+    resourcebundle:messages: [The following list was created by VisitScotland to showcase
+        a range of experiences. It isn’t ranked in any specific order.]
+    resourcebundle:messages_de: ['']
+    resourcebundle:messages_es: ['']
+    resourcebundle:messages_fr: ['']
+    resourcebundle:messages_it: ['']
+    resourcebundle:messages_nl: ['']

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/page-intro/page-intro.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/page-intro/page-intro.ftl
@@ -27,7 +27,7 @@
 <#-- @ftlvariable name="itinerary" type="com.visitscotland.brxm.model.ItineraryPage" -->
 <#-- @ftlvariable name="introTheme" type="int" -->
 
-<#macro pageIntro content heroDetails="" itinerary="" lightBackground=false author="" fullScreenMobile=false>
+<#macro pageIntro content heroDetails="" itinerary="" lightBackground=false author="" fullScreenMobile=false isListicle="">
     <@previewWarning editMode content alerts!"" />
     <#if lightBackground>
         <#assign themeName = themeCalculator(1)>
@@ -135,6 +135,11 @@
             <#if !searchResultsPage??>
                 <template v-slot:vs-intro-content>
                     <@hst.html hippohtml=content.introduction/>
+                    <#if isListicle??>
+                        <vs-rich-text-wrapper>
+                            <p class="mt-200">${label("listicle", "listicle.disclaimer")}</p>
+                        </vs-rich-text-wrapper>
+                    </#if>
                 </template>
             </#if>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/listicle-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/listicle-main.ftl
@@ -28,6 +28,17 @@
 
     <@pageIntro content=document author=author/>
 
+    <vs-container>
+        <vs-row>
+            <vs-col md="8" cols="12">
+                <vs-rich-text-wrapper>
+                    <!-- This will be a label -->
+                    The following list was created by VisitScotland to showcase a range of experiences. It isn’t ranked in any specific order.
+                </vs-rich-text-wrapper>
+            </vs-col>
+        </vs-row>
+    </vs-container>
+
     <vs-container class="mt-150">
         <vs-row>
             <vs-col cols="12">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/listicle-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/listicle-main.ftl
@@ -32,8 +32,7 @@
         <vs-row>
             <vs-col md="8" cols="12">
                 <vs-rich-text-wrapper>
-                    <!-- This will be a label -->
-                    The following list was created by VisitScotland to showcase a range of experiences. It isn’t ranked in any specific order.
+                    ${label("listicle", "listicle.disclaimer")}
                 </vs-rich-text-wrapper>
             </vs-col>
         </vs-row>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/listicle-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/pages/listicle-main.ftl
@@ -26,17 +26,7 @@
 <div class="has-edit-button">
     <@hst.manageContent hippobean=document/>
 
-    <@pageIntro content=document author=author/>
-
-    <vs-container>
-        <vs-row>
-            <vs-col md="8" cols="12">
-                <vs-rich-text-wrapper>
-                    ${label("listicle", "listicle.disclaimer")}
-                </vs-rich-text-wrapper>
-            </vs-col>
-        </vs-row>
-    </vs-container>
+    <@pageIntro content=document author=author isListicle=true/>
 
     <vs-container class="mt-150">
         <vs-row>


### PR DESCRIPTION
Adds Listicle disclaimer label to backend and presents it on the front end in the page intro module. For ticket [VS-439](https://visitscotland.atlassian.net/browse/VS-439).

[VS-439]: https://visitscotland.atlassian.net/browse/VS-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ