### PR TITLE
NON-JIRA MAINT: set -eo with try/catch block and invalidation of the …

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -10,8 +10,7 @@ def MAIL_TO_NET = 'net@visitscotland.com'
 def CC_DEV1 = 'Jose.Calcines@visitscotland.com'
 def CC_DEV2 = 'Juanluis.Hurtado@visitscotland.com'
 def CC_DEV3 = 'Matthew.Syrigos@visitscotland.com'
-def CC_DEV4 = 'Martin.Taylor@visitscotland.com'
-def CC_DEV_LIST = "cc:${CC_DEV1}, cc:${CC_DEV2}, cc:${CC_DEV3}, cc:${CC_DEV4}"
+def CC_DEV_LIST = "cc:${CC_DEV1}, cc:${CC_DEV2}, cc:${CC_DEV3}"
 
 def thisAgent
 // Define the SSR filename
@@ -397,7 +396,13 @@ pipeline {
                     }
                     steps{
                         script{
-                            sh 'mvn --batch-mode deploy -Pdist 2>&1 | tee $GIT_COMMIT.log'
+                            try {
+                                // detect errors in piped commands, catch them and invalidate the workflow, should they occur
+                                sh 'set -eo pipefail; mvn --batch-mode deploy -Pdist 2>&1 | tee $GIT_COMMIT.log'
+                            } catch (err) {
+                                echo "ERROR: Stage 'Snapshot to Nexus' failed for commit $GIT_COMMIT! (log: $GIT_COMMIT.log)"
+                                error("Stopping pipeline. Deployment failed in stage 'Snapshot to Nexus'")
+                            }
                         }
                     }
                 }
@@ -410,7 +415,13 @@ pipeline {
                     }
                     steps{
                         script{
-                            sh 'mvn --batch-mode deploy -Pdist-with-development-data 2>&1 | tee $GIT_COMMIT.log'
+                            try {
+                                // detect errors in piped commands, catch them and invalidate the workflow, should they occur
+                                sh 'set -eo pipefail; mvn --batch-mode deploy -Pdist-with-development-data 2>&1 | tee $GIT_COMMIT.log'
+                            } catch (err) {
+                                echo "ERROR: Stage 'Snapshot (dev data) to Nexus' failed for commit $GIT_COMMIT! (log: $GIT_COMMIT.log)"
+                                error("Stopping pipeline. Deployment failed in stage 'Snapshot (dev data) to Nexus'")
+                            }
                         }
                     }
                 }
@@ -424,7 +435,15 @@ pipeline {
                         }
                     }
                     steps {
-                        sh 'mvn --batch-mode deploy -Pdist 2>&1 | tee $GIT_COMMIT.log'
+                        script {
+                            try {
+                                // detect errors in piped commands, catch them and invalidate the workflow, should they occur
+                                sh 'set -eo pipefail; mvn --batch-mode deploy -Pdist 2>&1 | tee $GIT_COMMIT.log'
+                            } catch (err) {
+                                echo "ERROR: Stage 'Release to Nexus' failed for commit $GIT_COMMIT! (log: $GIT_COMMIT.log)"
+                                error("Stopping pipeline. Deployment failed in stage 'Release to Nexus'")
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…build

set -e: Exit the shell if any command fails.
set -o pipefail: Causes the shell to exit if any part of the pipeline fails (not just the last command).

The above options were very much needed, because without them, any error that may occur during the mvn command, would be piped to the tee command, the tee command would succeed and the pipeline workflow wouldn't fail, even with a failed build. With this change, the pipeline is properly invalidated when the build fails, and the user is notified of the outcome.

The try/catch blocks are essential, as this change has been applied on stages that run in parallel and the logged messages can be mixed up, due to the nature of the parallel execution.

cc: @jlrhurta , @jcalcines 