### PR TITLE
Add import statement

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/megalinks/cardgroup.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/megalinks/cardgroup.ftl
@@ -1,4 +1,5 @@
 <#include "../../../../include/imports.ftl">
+<#include "../../../../frontend/components/vs-megalinks.ftl">
 <#include "./card-group/megalinks-card-group.ftl">
 <#include "../../global/preview-warning.ftl">
 


### PR DESCRIPTION
This defect wasn't noticed because in all previous test environments there was already another example of a megalinks layout on the page. 