### PR TITLE
new css file and link to patch for short-term spotlight spacing

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/assets/css/spotlight-section.css
+++ b/repository-data/webfiles/src/main/resources/site/assets/css/spotlight-section.css
@@ -1,0 +1,8 @@
+/* Temporary fix for lack of whitespace between spotlight and content modules with grey backgrounds. Can be deleted when grey backgrounds have been removed from navigation pages */
+
+[class$="--grey"] + [id^="section-"]:has(.vs-spotlight-section) {
+    margin-top: 5rem;
+}
+[id^="section-"]:has(.vs-spotlight-section) + [id^="section-"]:has(> [class$="--grey"]) {
+    margin-top: 5rem;
+}

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/base/footerContributions.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/base/footerContributions.ftl
@@ -26,5 +26,6 @@
 
         <link rel="stylesheet" href="<@hst.webfile path='/assets/css/fouc.css'/>" type="text/css"/>
         <link rel="stylesheet" href="<@hst.webfile path='/assets/css/personalisation.css'/>" type="text/css"/>
+        <link rel="stylesheet" href="<@hst.webfile path='/assets/css/spotlight-section.css'/>" type="text/css"/>
     </#compress>
 </#macro>


### PR DESCRIPTION
`Vs-Spotlight-Section` (or `vs-spotlight-section` as it's invoked in this codebase), behaves exactly as a UI library component should in terms of responsive behaviour and peripheral whitespace: it's block-like, expanding horizontally as much as it can and has no instrinsic margin or padding.

This anticipates a future in which the UIs' spatial relationships are governed by a separate layout layer, which is where we want to be. But as of now, that's not how it works; we can't easily reason about whitespace between content modules because for historical reasons UI components from the Vue library tend to have vertical padding and margin baked in.

So. It's kinda gnarly to stick this seemingly arbitrary CSS into its own file and include it in the footer contributions, but I've considered it from a dozen angles and I believe this is the smallest, simplest, cleanest, most rational and easily deletable way to reconcile the current user requirements with the overall direction of travel.  