### PR TITLE
fix(itinerary): adjust spacing to account for larger headings

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/page-intro/page-intro.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/page-intro/page-intro.ftl
@@ -157,14 +157,14 @@
                     <template v-slot:vs-intro-lower>
                         <vs-container >
                             <vs-row>
-                                <vs-col cols="12" lg="5" xl="6" offset-lg="1">
+                                <vs-col cols="12" xxl="6">
                                     <vs-description-list class="mb-150">
                                         <vs-description-list-item title>
                                             ${label("itinerary", "highlights")}
                                         </vs-description-list-item>
 
                                         <#list itinerary.document.highlights as highlight>
-                                            <vs-description-list-item>
+                                            <vs-description-list-item class="<#if highlight?is_first>mt-050</#if>">
                                                 ${highlight}
                                             </vs-description-list-item>
                                         </#list>
@@ -175,8 +175,8 @@
                                             ${label("itinerary", "areas-covered")}
                                         </vs-description-list-item>
 
-                                        <#list  itinerary.document.areas as area>
-                                            <vs-description-list-item>
+                                        <#list itinerary.document.areas as area>
+                                            <vs-description-list-item class="<#if area?is_first>mt-050</#if>">
                                                 ${label("areas", "${area}")}
                                             </vs-description-list-item>
                                         </#list>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/page-intro/page-intro.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/visitscotland/macros/modules/page-intro/page-intro.ftl
@@ -157,7 +157,7 @@
                     <template v-slot:vs-intro-lower>
                         <vs-container >
                             <vs-row>
-                                <vs-col cols="12" xxl="6">
+                                <vs-col cols="12" xxl="6" offset-lg="1">
                                     <vs-description-list class="mb-150">
                                         <vs-description-list-item title>
                                             ${label("itinerary", "highlights")}


### PR DESCRIPTION
The slight change to heading sizes in V5 was causing this to have some ugly overlaps on specifically lg and xl screen sizes. This removes some breakpoints and adjusts a couple of  margins to bring that in line with the expected layout

<img width="970" height="433" alt="image" src="https://github.com/user-attachments/assets/bd427e6f-de27-4551-bd21-52741f6dca19" />

<img width="978" height="379" alt="image" src="https://github.com/user-attachments/assets/799dee38-1703-4b0b-845f-ecbe5c5ab0a8" />
